### PR TITLE
Separate dev dependencies into optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,6 @@ readme = "README.md"
 dependencies = [
   'pandas',
   'numpy',
-
-  'build', # Building the package
-  'hatchling', # Build system
-  'hatch-vcs', # Auto version numbering from GitHub
-  'twine', # Publishing to PyPi
-  'pdoc', # Generating docs from docstrings
-  'flake8', # Build tests
-  'pytest' # Build tests
 ]
 requires-python = ">=3.6"
 classifiers = [
@@ -42,6 +34,17 @@ classifiers = [
 
 keywords = ["data", "analytics", "binary", "pandas", "hex", "hexadecimal"] 
 license = {file = "LICENSE"}
+
+[project.optional-dependencies]
+dev = [
+  'build', # Building the package
+  'hatchling', # Build system
+  'hatch-vcs', # Auto version numbering from GitHub
+  'twine', # Publishing to PyPi
+  'pdoc', # Generating docs from docstrings
+  'flake8', # Build tests
+  'pytest' # Build tests
+]
 
 [project.urls]
 "Homepage" = "https://github.com/jamiecash/binda"


### PR DESCRIPTION
Addresses #5 

Now users installing the package will only pull in actual run time dependencies. Developers on the package can get all of the optional dev dependencies locally using `pip install -e .[dev]` (In my terminal I had to escape the brackets so `pip install -e .\[dev\]`. I'm not sure if that's true outside of zsh).